### PR TITLE
Change path to config file

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -776,7 +776,7 @@ ENDDATA;
 		// Check for configuration file writeable.
 		$option = new stdClass;
 		$option->label  = JText::sprintf('COM_JOOMLAUPDATE_INSTL_WRITABLE', 'configuration.php');
-		$option->state  = (is_writable('../configuration.php') || (!file_exists('../configuration.php') && is_writable('../')));
+		$option->state  = (is_writable(JPATH_ROOT . '/configuration.php') || (!file_exists(JPATH_ROOT . '/configuration.php') && is_writable(JPATH_ROOT)));
 		$option->notice = ($option->state) ? null : JText::_('COM_JOOMLAUPDATE_INSTL_NOTICEYOUCANSTILLINSTALL');
 		$options[] = $option;
 


### PR DESCRIPTION
Visually, the path to the configuration file looks like it was checking in the update component's folder to see if the config file was writable, when it should be checking the site root.
